### PR TITLE
Add link page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,6 +4,7 @@
     <h1 class="logo"><a href="{{ '/' | prepend: site.baseurl }}">{{ site.title }}<span>{{ site.title2 }}</span></a></h1>
     <ul class="navbar">
       <li><a href="{{ '/about' | prepend: site.baseurl }}">About</a></li>
+      <li><a href="{{ '/links' | prepend: site.baseurl }}">Links</a></li>
       <li><a href="{{ "/feed.xml" | prepend: site.baseurl }}" target="_blank">RSS</a></li>
     </ul>
   </div>

--- a/links.md
+++ b/links.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Links
+permalink: /links/
+---
+
+これまでの勉強会の資料などへのリンク集です．
+
+### 機械学習入門勉強会
+
+「続・わかりやすいパターン認識」という本の輪読を行う勉強会です．
+
+- [第1章ベイズ統計学](http://www.slideshare.net/moritama1515/ss-63834072)
+- [第2章事前確率と事後確率](https://www.lapis-zero09.xyz/24th.html)
+- [第6章EMアルゴリズム](http://www.slideshare.net/moritama1515/em-67669045)


### PR DESCRIPTION
勉強会の過去資料へのリンクページをつくってみました．
現状は `slis-ml.github.io/links.md` に直接リンクを書いています（ので新しいリンク追加する場合はこのファイルを編集してみてください．）．

slackから見つけられた資料へのリンクもPRの中に入っています（画像にある3つ分）

![2016-11-11 20 58 14](https://cloud.githubusercontent.com/assets/7121753/20214470/bdc89dc2-a851-11e6-89dd-22d4194d2078.png)
